### PR TITLE
fix: add missing message parameter to safeReply calls

### DIFF
--- a/index.js
+++ b/index.js
@@ -275,6 +275,7 @@ client.on('messageCreate', async (message) => {
     const gonderenData = await bakiyeGetir(message.author.id)
     if (gonderenData.balance < miktar) {
       return await safeReply(
+        message,
         `❌ Yetersiz bakiye! Mevcut bakiyen: **${gonderenData.balance} Silver**`
       )
     }
@@ -288,6 +289,7 @@ client.on('messageCreate', async (message) => {
     if (transferSonuc.error) {
       if (transferSonuc.error === 'yetersiz_bakiye') {
         return await safeReply(
+          message,
           `❌ Yetersiz bakiye! Mevcut bakiyen: **${transferSonuc.balance} Silver**`
         )
       }


### PR DESCRIPTION
Fixes #1

## Problem
The `safeReply` function was being called without the required `message` parameter in the transfer command handler, causing the bot to fail silently when users had insufficient balance.

## Changes
- Added missing `message` parameter to `safeReply` call at line 277
- Added missing `message` parameter to `safeReply` call at line 291

## Before (Bug)
```js
return await safeReply(
  `❌ Yetersiz bakiye! Mevcut bakiyen: **${gonderenData.balance} Silver**`
)
```

## After (Fixed)
```js
return await safeReply(
  message,
  `❌ Yetersiz bakiye! Mevcut bakiyen: **${gonderenData.balance} Silver**`
)
```